### PR TITLE
WIP Attach user JWT to every crawl requests

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -3,11 +3,10 @@ import { getConfig } from './config';
 import Model from './model';
 
 export const sendNewGaiaUrl = async (gaiaURL: string): Promise<boolean> => {
-  const { apiServer, userSession } = getConfig();
+  const { apiServer } = getConfig();
   const url = `${apiServer}/radiks/models/crawl`;
-  const jwt = userSession.loadUserData().authResponseToken;
   // console.log(url, gaiaURL);
-  const data = { gaiaURL, jwt };
+  const data = { gaiaURL };
   const response = await fetch(url, {
     method: 'POST',
     body: JSON.stringify(data),

--- a/src/api.ts
+++ b/src/api.ts
@@ -3,10 +3,11 @@ import { getConfig } from './config';
 import Model from './model';
 
 export const sendNewGaiaUrl = async (gaiaURL: string): Promise<boolean> => {
-  const { apiServer } = getConfig();
+  const { apiServer, userSession } = getConfig();
   const url = `${apiServer}/radiks/models/crawl`;
+  const jwt = userSession.loadUserData().authResponseToken;
   // console.log(url, gaiaURL);
-  const data = { gaiaURL };
+  const data = { gaiaURL, jwt };
   const response = await fetch(url, {
     method: 'POST',
     body: JSON.stringify(data),

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -74,12 +74,13 @@ export default class BlockstackUser extends Model {
         }).finally(() => {
           // console.log(user.attrs);
           const userData = loadUserData();
-          const { username, profile, appPrivateKey } = userData;
+          const { username, profile, appPrivateKey, authResponseToken } = userData;
           const publicKey = getPublicKeyFromPrivate(appPrivateKey);
           user.update({
             username,
             profile,
             publicKey,
+            authResponseToken,
           });
           if (!user.attrs.personalSigningKeyId) {
             user.createSigningKey().then((key) => {


### PR DESCRIPTION
Close #37 

Send the user jwt to every crawl request.
Get the token with `userSession.loadUserData().authResponseToken` and send it as `jwt` body param.