### PR TITLE
Adds model config to validate usernames

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,11 @@ A client-side framework for building model-driven decentralized applications on 
     - [Saving a model](#saving-a-model)
     - [Deleting a model](#deleting-a-model)
   - [Querying models](#querying-models)
+  - [Counting models](#counting-models)
   - [Fetching models created by the current user](#fetching-models-created-by-the-current-user)
   - [Managing relational data](#managing-relational-data)
   - [Extending the user model](#extending-the-user-model)
+  - [Validating usernames](#validating-usernames)
 - [Collaboration](#collaboration)
   - [UserGroup Model](#usergroup-model)
   - [General Workflow](#general-workflow)
@@ -411,6 +413,21 @@ class MyAppUserModel extends User {
   };
 }
 ~~~
+
+### Validating usernames
+
+There are many situations where it is important to validate usernames that are associated with models in your app. For example, imagine a social network, where each post is tied to a specific Blockstack ID. You need to have some validation to ensure that the user who created that model is the same user who owns that Blockstack ID. Radiks can do this for you, as long as you add a special flag to your model, called `validateUsername`.
+
+~~~javascript
+class ModelWithUsername extends Model {
+  static validateUsername = true
+  static schema = { ... }
+}
+~~~
+
+If you include this special `validateUsername` flag, then Radiks will pass on the necessar information to Radiks-server. Radiks-server will then perform some validation to ensure that model was indeed created by the username that they claim to have.
+
+One important thing to note here is that this configuration requires you to use the `publish-data` scope when logging in with Blockstack.
 
 ## Collaboration
 

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -30,3 +30,14 @@ export const fakeModel = () => {
   });
   return model;
 };
+
+export class ModelWithUsername extends Model {
+  static validateUsername = true;
+
+  static schema = {
+    message: {
+      type: String,
+      decrypted: true,
+    },
+  }
+}

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -1,9 +1,10 @@
 import './mocks/crypto';
 import './setup';
 import { verifyECDSA } from 'blockstack/lib/encryption';
-import { fakeModel, TestModel } from './helpers';
+import { fakeModel, TestModel, ModelWithUsername } from './helpers';
 import User from '../src/models/user';
 import SigningKey from '../src/models/signing-key';
+import { getConfig } from '../src/config';
 
 test('encrypts data', async (t) => {
   // crypto.getRandomValues(16);
@@ -89,4 +90,14 @@ test('it return null if model not found', async () => {
   expect(modelFindById).toBe(undefined);
   const modelFindOne = await TestModel.findOne({ _id: 'notfound' });
   expect(modelFindOne).toBe(undefined);
+});
+
+test.only('it includes username if validateUsername', async () => {
+  const user = await User.createWithCurrentUser();
+  const model = new ModelWithUsername({ message: 'hello' });
+  await model.save();
+  expect(model.attrs.username).toEqual(user.attrs.username);
+  expect(model.attrs.gaiaURL).not.toBeFalsy();
+  const gaiaURL = `https://gaia.blockstack.org/hub/1Me2Zi84EioQJcwDg5Kjgy5YaXgqXjxJYS/ModelWithUsername/${model._id}`;
+  expect(model.attrs.gaiaURL).toEqual(gaiaURL);
 });

--- a/test/setup.js
+++ b/test/setup.js
@@ -96,6 +96,10 @@ beforeEach(async () => {
     userData: {
       appPrivateKey,
       username: faker.name.findName(),
+      gaiaHubConfig: {
+        url_prefix: 'https://gaia.blockstack.org/hub/', // eslint-disable-line @typescript-eslint/camelcase
+        address: '1Me2Zi84EioQJcwDg5Kjgy5YaXgqXjxJYS',
+      },
       profile: {
         // TODO
       },


### PR DESCRIPTION
This adds a static property to `Model` called `validateUsername`. By default, this is false. If `true`, then Radiks will save the current user's username when saving data. This is really all that is needed to send to Radiks-server, which does all of the actual validation.

cc @moxiegirl, @pradel , @friedger who have expressed interest here.